### PR TITLE
Minimalistic unit/render testing with KCL

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -14,6 +14,7 @@ PLATFORMS ?= linux_amd64
 UP_VERSION = v0.31.0
 UP_CHANNEL = stable
 UPTEST_VERSION = v0.11.1
+CROSSPLANE_CLI_VERSION = v1.16.0
 
 -include build/makelib/k8s_tools.mk
 # ====================================================================================
@@ -78,8 +79,13 @@ uptest: $(UPTEST) $(KUBECTL) $(KUTTL)
 # - UPTEST_CLOUD_CREDENTIALS, cloud credentials for the provider being tested, e.g. export UPTEST_CLOUD_CREDENTIALS=$(cat azure.json)
 e2e: check build controlplane.down controlplane.up local.xpkg.deploy.configuration.$(PROJECT_NAME) uptest ## Run uptest together with all dependencies. Use `make e2e SKIP_DELETE=--skip-delete` to skip deletion of resources.
 
-render: ## Crossplane render
-	crossplane beta render examples/network-xr.yaml apis/default/composition.yaml examples/function/function.yaml -r
+render: $(CROSSPLANE_CLI) ## Crossplane render
+	$(CROSSPLANE_CLI) beta render examples/network-xr.yaml apis/default/composition.yaml examples/function/function.yaml -r
+
+render.test: $(CROSSPLANE_CLI) $(KCL)
+	$(CROSSPLANE_CLI) beta render examples/network-xr.yaml apis/default/composition.yaml examples/function/function.yaml -r > ./.cache/render.yaml
+	$(KCL) test
+
 
 yamllint: ## Static yamllint check
 	@$(INFO) running yamllint

--- a/render_test.k
+++ b/render_test.k
@@ -1,0 +1,28 @@
+import file
+import yaml
+
+getByCompositeResourceName = lambda name: str -> any {
+   render = yaml.decode_all(file.read(".cache/render.yaml"))
+   resource = [ el for el in render if el.metadata.annotations?["crossplane.io/composition-resource-name"] == name][0]
+   resource
+}
+
+test_vnet_name = lambda {
+   virtualNetwork = getByCompositeResourceName("virtualNetwork")
+   assert virtualNetwork.metadata.name == "ref-azure-network-from-xr-vnet"
+}
+
+test_vnet_address = lambda {
+   virtualNetwork = getByCompositeResourceName("virtualNetwork")
+   assert virtualNetwork.spec.forProvider.addressSpace[0] == "192.168.0.0/16"
+}
+
+test_vnet_region = lambda {
+   virtualNetwork = getByCompositeResourceName("virtualNetwork")
+   assert virtualNetwork.spec.forProvider.location == "westus"
+}
+
+test_subnet_svc_endpoints_sql = lambda {
+   subnet = getByCompositeResourceName("subnet")
+   assert subnet.spec.forProvider.serviceEndpoints[0] == "Microsoft.Sql"
+}


### PR DESCRIPTION

<!--
Thank you for helping to improve Upbound!

Please read through https://git.io/fj2m9 if this is your first time opening an
Upbound pull request. Find us in https://slack.crossplane.io/messages/upbound if
you need any help contributing.
-->

### Description of your changes

* Use KCL for quick evaluation of render yaml stream
* Wrapped in simple `make render.test` target
* Test suite is located at `render_test.k`
* Enables fast feedback and TDD-like development flow for Composition building
* Works with any function pipeline and is not limited to function-kcl implementation. This specific Configuration is P&T based


I have:

- [ ] Read and followed Upbound's [contribution process](https://git.io/fj2m9).
- [ ] Run `make reviewable` to ensure this PR is ready for review.
- [ ] Added `backport release-x.y` labels to auto-backport this PR, as appropriate.

### How has this code been tested

`make render.test`