### PR TITLE
Update uptest, skip `.cache` from xpkg

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -13,14 +13,14 @@ PLATFORMS ?= linux_amd64
 
 UP_VERSION = v0.31.0
 UP_CHANNEL = stable
-UPTEST_VERSION = v0.11.1
+UPTEST_VERSION = v0.13.1
 CROSSPLANE_CLI_VERSION = v1.16.0
 
 -include build/makelib/k8s_tools.mk
 # ====================================================================================
 # Setup XPKG
 XPKG_DIR = $(shell pwd)
-XPKG_IGNORE = .github/workflows/*.yaml,.github/workflows/*.yml,examples/*.yaml,.work/uptest-datasource.yaml
+XPKG_IGNORE = .github/workflows/*.yaml,.github/workflows/*.yml,examples/*.yaml,.work/uptest-datasource.yaml,.cache/*.yaml
 XPKG_REG_ORGS ?= xpkg.upbound.io/upbound
 # NOTE(hasheddan): skip promoting on xpkg.upbound.io as channel tags are
 # inferred.

--- a/crossplane.yaml
+++ b/crossplane.yaml
@@ -21,4 +21,4 @@ spec:
       version: "v1.4.0"
     - function: xpkg.upbound.io/crossplane-contrib/function-patch-and-transform
       # renovate: datasource=github-releases depName=crossplane-contrib/function-patch-and-transform
-      version: "v0.6.0"
+      version: "v0.7.0"


### PR DESCRIPTION

<!--
Thank you for helping to improve Upbound!

Please read through https://git.io/fj2m9 if this is your first time opening an
Upbound pull request. Find us in https://slack.crossplane.io/messages/upbound if
you need any help contributing.
-->

### Description of your changes

<!--
Briefly describe what this pull request does. Be sure to direct your reviewers'
attention to anything that needs special consideration.

We love pull requests that resolve an open issue. If yours does, use the below
line to indicate which issue your PR fixes, for example "Fixes #500":
-->

* Update uptest to latest version
* Skip `.cache/*.yaml` from xpkg, required after #55
* Inline update of function-patch-and-transform to latest


I have:

- [ ] Read and followed Upbound's [contribution process](https://git.io/fj2m9).
- [ ] Run `make reviewable` to ensure this PR is ready for review.
- [ ] Added `backport release-x.y` labels to auto-backport this PR, as appropriate.

### How has this code been tested

```console
make e2e
...
--- PASS: kuttl (433.67s)
    --- PASS: kuttl/harness (0.00s)
        --- PASS: kuttl/harness/case (433.50s)
PASS
07:08:02 [ OK ] running automated tests