### PR TITLE
Switch back to action-up with skip-login for Composition Tests workflow

### DIFF
--- a/.github/workflows/composition-tests.yaml
+++ b/.github/workflows/composition-tests.yaml
@@ -15,10 +15,9 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Install up
-        run: |
-          curl -sL "https://cli.upbound.io" | sh
-          mv up /usr/local/bin
-          chmod +x /usr/local/bin/up
+        uses: upbound/action-up@v1
+        with:
+          skip-login: true
 
       - name: Build project
         run: up project build


### PR DESCRIPTION
<!--
Thank you for helping to improve Upbound!

Please read through https://git.io/fj2m9 if this is your first time opening an
Upbound pull request. Find us in https://slack.crossplane.io/messages/upbound if
you need any help contributing.
-->

### Description of your changes

Use action-up for up installation without authentication

I have:

- [x] Read and followed Upbound's [contribution process](https://git.io/fj2m9).
- [ ] Run `make reviewable` to ensure this PR is ready for review.
- [ ] Added `backport release-x.y` labels to auto-backport this PR, as appropriate.

### How has this code been tested

workflow run below