### PR TITLE
Prepare network configuration for Flexible Server

### DIFF
--- a/apis/xnetworks/definition.yaml
+++ b/apis/xnetworks/definition.yaml
@@ -27,6 +27,18 @@ spec:
                   region:
                     type: string
                     description: Region is the region you'd like your resource to be created in.
+                  addressSpace:
+                    type: string
+                    description: Address space for the virtual network in CIDR notation.
+                    default: "10.0.0.0/16"
+                  generalSubnetPrefix:
+                    type: string
+                    description: Address prefix for the general subnet in CIDR notation.
+                    default: "10.0.1.0/24"
+                  databaseSubnetPrefix:
+                    type: string
+                    description: Address prefix for the database subnet in CIDR notation.
+                    default: "10.0.2.0/24"
                   deletionPolicy:
                     description: Delete the external resources when the Claim/XR is deleted. Defaults to Delete
                     enum:

--- a/apis/xnetworks/definition.yaml
+++ b/apis/xnetworks/definition.yaml
@@ -27,17 +27,30 @@ spec:
                   region:
                     type: string
                     description: Region is the region you'd like your resource to be created in.
-                  addressSpace:
+                  addressRange:
                     type: string
-                    description: Address space for the virtual network in CIDR notation.
+                    description: Address range (CIDR block) for the virtual network
                     default: "10.0.0.0/16"
-                  generalSubnetPrefix:
+                  generalSubnetRange:
                     type: string
-                    description: Address prefix for the general subnet in CIDR notation.
+                    description: Address range (CIDR block) for the general subnet
                     default: "10.0.1.0/24"
-                  databaseSubnetPrefix:
-                    type: string
-                    description: Address prefix for the database subnet in CIDR notation. If not specified, no database subnet will be created.
+                  databaseSubnets:
+                    type: array
+                    description: List of database subnets to create
+                    items:
+                      type: object
+                      properties:
+                        addressRange:
+                          type: string
+                          description: Address range (CIDR block) for the database subnet
+                        serviceType:
+                          type: string
+                          description: Type of database service to use (postgresql or mysql)
+                          enum: ["postgresql", "mysql"]
+                      required:
+                        - addressRange
+                        - serviceType
                   deletionPolicy:
                     description: Delete the external resources when the Claim/XR is deleted. Defaults to Delete
                     enum:

--- a/apis/xnetworks/definition.yaml
+++ b/apis/xnetworks/definition.yaml
@@ -37,8 +37,7 @@ spec:
                     default: "10.0.1.0/24"
                   databaseSubnetPrefix:
                     type: string
-                    description: Address prefix for the database subnet in CIDR notation.
-                    default: "10.0.2.0/24"
+                    description: Address prefix for the database subnet in CIDR notation. If not specified, no database subnet will be created.
                   deletionPolicy:
                     description: Delete the external resources when the Claim/XR is deleted. Defaults to Delete
                     enum:

--- a/examples/network-xr-with-db.yaml
+++ b/examples/network-xr-with-db.yaml
@@ -1,0 +1,11 @@
+apiVersion: azure.platform.upbound.io/v1alpha1
+kind: XNetwork
+metadata:
+  name: ref-azure-network
+spec:
+  parameters:
+    id: ref-azure-network-from-xr
+    region: westus
+    addressSpace: 10.0.0.0/16
+    generalSubnetPrefix: 10.0.1.0/24
+    databaseSubnetPrefix: 10.0.2.0/24

--- a/examples/network-xr-with-multiple-dbs.yaml
+++ b/examples/network-xr-with-multiple-dbs.yaml
@@ -8,5 +8,8 @@ spec:
     region: westus
     addressRange: 10.0.0.0/16
     generalSubnetRange: 10.0.1.0/24
-    deletionPolicy: Delete
-    providerConfigName: default
+    databaseSubnets:
+      - addressRange: 10.0.2.0/24
+        serviceType: postgresql
+      - addressRange: 10.0.3.0/24
+        serviceType: mysql

--- a/examples/network-xr-with-mysql-db.yaml
+++ b/examples/network-xr-with-mysql-db.yaml
@@ -6,6 +6,8 @@ spec:
   parameters:
     id: ref-azure-network-from-xr
     region: westus
-    addressSpace: 10.0.0.0/16
-    generalSubnetPrefix: 10.0.1.0/24
-    databaseSubnetPrefix: 10.0.2.0/24
+    addressRange: 10.0.0.0/16
+    generalSubnetRange: 10.0.1.0/24
+    databaseSubnets:
+      - addressRange: 10.0.2.0/24
+        serviceType: mysql

--- a/examples/network-xr-with-pg-db.yaml
+++ b/examples/network-xr-with-pg-db.yaml
@@ -8,5 +8,8 @@ spec:
     region: westus
     addressRange: 10.0.0.0/16
     generalSubnetRange: 10.0.1.0/24
+    databaseSubnets:
+      - addressRange: 10.0.2.0/24
+        serviceType: postgresql
     deletionPolicy: Delete
     providerConfigName: default

--- a/functions/xnetwork/main.k
+++ b/functions/xnetwork/main.k
@@ -31,7 +31,8 @@ _add_common_spec_fields = lambda spec: any -> any {
     }
 }
 
-_items = [
+# Base network resources
+_base_resources = [
     # Resource Group
     azurev1beta1.ResourceGroup {
         metadata = _metadata("${params.id}-rg")
@@ -72,8 +73,10 @@ _items = [
             }
         })
     }
+]
 
-    # Delegated Subnet for Database Flexible Server
+# Database subnet (optional)
+_database_subnet = [
     networkv1beta2.Subnet {
         metadata = _metadata("${params.id}-db-sn")
         spec = _add_common_spec_fields(networkv1beta2.NetworkAzureUpboundIoV1beta2SubnetSpec {
@@ -96,6 +99,6 @@ _items = [
             }
         })
     }
-]
+] if "databaseSubnetPrefix" in params else []
 
-items = _items
+items = _base_resources + _database_subnet

--- a/functions/xnetwork/main.k
+++ b/functions/xnetwork/main.k
@@ -76,7 +76,7 @@ _base_resources = [
 ]
 
 # Database subnets (optional)
-_subnets_from_spec = params.databaseSubnets if params.databaseSubnets != Undefined else []
+_subnets_from_spec = params.databaseSubnets or []
 _database_subnets = [
     networkv1beta2.Subnet {
         metadata = _metadata("${params.id}-db-sn-${index}")

--- a/functions/xnetwork/main.k
+++ b/functions/xnetwork/main.k
@@ -99,6 +99,6 @@ _database_subnet = [
             }
         })
     }
-] if "databaseSubnetPrefix" in params else []
+] if params.databaseSubnetPrefix != Undefined else []
 
 items = _base_resources + _database_subnet

--- a/functions/xnetwork/main.k
+++ b/functions/xnetwork/main.k
@@ -48,7 +48,7 @@ _items = [
         spec = _add_common_spec_fields(networkv1beta2.NetworkAzureUpboundIoV1beta2VirtualNetworkSpec {
             forProvider = {
                 location = params.region
-                addressSpace = ["10.0.0.0/16"]
+                addressSpace = [params.addressSpace]
                 resourceGroupNameSelector = {
                     matchControllerRef = True
                 }
@@ -61,7 +61,7 @@ _items = [
         metadata = _metadata("${params.id}-sn")
         spec = _add_common_spec_fields(networkv1beta2.NetworkAzureUpboundIoV1beta2SubnetSpec {
             forProvider = {
-                addressPrefixes = ["10.0.1.0/24"]
+                addressPrefixes = [params.generalSubnetPrefix]
                 resourceGroupNameSelector = {
                     matchControllerRef = True
                 }
@@ -73,12 +73,12 @@ _items = [
         })
     }
 
-    # Delegated Subnet for PostgreSQL Flexible Server
+    # Delegated Subnet for Database Flexible Server
     networkv1beta2.Subnet {
-        metadata = _metadata("${params.id}-psql-sn")
+        metadata = _metadata("${params.id}-db-sn")
         spec = _add_common_spec_fields(networkv1beta2.NetworkAzureUpboundIoV1beta2SubnetSpec {
             forProvider = {
-                addressPrefixes = ["10.0.2.0/24"]
+                addressPrefixes = [params.databaseSubnetPrefix]
                 delegation = [{
                     name = "fs"
                     serviceDelegation = {

--- a/functions/xnetwork/main.k
+++ b/functions/xnetwork/main.k
@@ -49,7 +49,7 @@ _base_resources = [
         spec = _add_common_spec_fields(networkv1beta2.NetworkAzureUpboundIoV1beta2VirtualNetworkSpec {
             forProvider = {
                 location = params.region
-                addressSpace = [params.addressSpace]
+                addressSpace = [params.addressRange]
                 resourceGroupNameSelector = {
                     matchControllerRef = True
                 }
@@ -62,7 +62,7 @@ _base_resources = [
         metadata = _metadata("${params.id}-sn")
         spec = _add_common_spec_fields(networkv1beta2.NetworkAzureUpboundIoV1beta2SubnetSpec {
             forProvider = {
-                addressPrefixes = [params.generalSubnetPrefix]
+                addressPrefixes = [params.generalSubnetRange]
                 resourceGroupNameSelector = {
                     matchControllerRef = True
                 }
@@ -75,29 +75,21 @@ _base_resources = [
     }
 ]
 
-# Database subnet (optional)
-_database_subnet = [
+# Database subnets (optional)
+_subnets_from_spec = params.databaseSubnets if params.databaseSubnets != Undefined else []
+_database_subnets = [
     networkv1beta2.Subnet {
-        metadata = _metadata("${params.id}-db-sn")
+        metadata = _metadata("${params.id}-db-sn-${index}")
         spec = _add_common_spec_fields(networkv1beta2.NetworkAzureUpboundIoV1beta2SubnetSpec {
             forProvider = {
-                addressPrefixes = [params.databaseSubnetPrefix]
-                delegation = [
-                    {
-                        name = "fs-postgresql"
-                        serviceDelegation = {
-                            actions = ["Microsoft.Network/virtualNetworks/subnets/join/action"]
-                            name = "Microsoft.DBforPostgreSQL/flexibleServers"
-                        }
-                    },
-                    {
-                        name = "fs-mysql"
-                        serviceDelegation = {
-                            actions = ["Microsoft.Network/virtualNetworks/subnets/join/action"]
-                            name = "Microsoft.DBforMySQL/flexibleServers"
-                        }
+                addressPrefixes = [subnet.addressRange]
+                delegation = [{
+                    name = "fs"
+                    serviceDelegation = {
+                        actions = ["Microsoft.Network/virtualNetworks/subnets/join/action"]
+                        name = "Microsoft.DBforPostgreSQL/flexibleServers" if subnet.serviceType == "postgresql" else "Microsoft.DBforMySQL/flexibleServers"
                     }
-                ]
+                }]
                 resourceGroupNameSelector = {
                     matchControllerRef = True
                 }
@@ -107,7 +99,7 @@ _database_subnet = [
                 }
             }
         })
-    }
-] if params.databaseSubnetPrefix != Undefined else []
+    } for index, subnet in _subnets_from_spec
+]
 
-items = _base_resources + _database_subnet
+items = _base_resources + _database_subnets

--- a/functions/xnetwork/main.k
+++ b/functions/xnetwork/main.k
@@ -48,7 +48,7 @@ _items = [
         spec = _add_common_spec_fields(networkv1beta2.NetworkAzureUpboundIoV1beta2VirtualNetworkSpec {
             forProvider = {
                 location = params.region
-                addressSpace = ["192.168.0.0/16"]
+                addressSpace = ["10.0.0.0/16"]
                 resourceGroupNameSelector = {
                     matchControllerRef = True
                 }
@@ -56,16 +56,40 @@ _items = [
         })
     }
 
-    # Subnet
+    # Subnet for general use
     networkv1beta2.Subnet {
         metadata = _metadata("${params.id}-sn")
         spec = _add_common_spec_fields(networkv1beta2.NetworkAzureUpboundIoV1beta2SubnetSpec {
             forProvider = {
-                addressPrefixes = ["192.168.1.0/24"]
+                addressPrefixes = ["10.0.1.0/24"]
                 resourceGroupNameSelector = {
                     matchControllerRef = True
                 }
                 serviceEndpoints = ["Microsoft.Sql"]
+                virtualNetworkNameSelector = {
+                    matchControllerRef = True
+                }
+            }
+        })
+    }
+
+    # Delegated Subnet for PostgreSQL Flexible Server
+    networkv1beta2.Subnet {
+        metadata = _metadata("${params.id}-psql-sn")
+        spec = _add_common_spec_fields(networkv1beta2.NetworkAzureUpboundIoV1beta2SubnetSpec {
+            forProvider = {
+                addressPrefixes = ["10.0.2.0/24"]
+                delegation = [{
+                    name = "fs"
+                    serviceDelegation = {
+                        actions = ["Microsoft.Network/virtualNetworks/subnets/join/action"]
+                        name = "Microsoft.DBforPostgreSQL/flexibleServers"
+                    }
+                }]
+                resourceGroupNameSelector = {
+                    matchControllerRef = True
+                }
+                serviceEndpoints = ["Microsoft.Storage"]
                 virtualNetworkNameSelector = {
                     matchControllerRef = True
                 }

--- a/functions/xnetwork/main.k
+++ b/functions/xnetwork/main.k
@@ -82,13 +82,22 @@ _database_subnet = [
         spec = _add_common_spec_fields(networkv1beta2.NetworkAzureUpboundIoV1beta2SubnetSpec {
             forProvider = {
                 addressPrefixes = [params.databaseSubnetPrefix]
-                delegation = [{
-                    name = "fs"
-                    serviceDelegation = {
-                        actions = ["Microsoft.Network/virtualNetworks/subnets/join/action"]
-                        name = "Microsoft.DBforPostgreSQL/flexibleServers"
+                delegation = [
+                    {
+                        name = "fs-postgresql"
+                        serviceDelegation = {
+                            actions = ["Microsoft.Network/virtualNetworks/subnets/join/action"]
+                            name = "Microsoft.DBforPostgreSQL/flexibleServers"
+                        }
+                    },
+                    {
+                        name = "fs-mysql"
+                        serviceDelegation = {
+                            actions = ["Microsoft.Network/virtualNetworks/subnets/join/action"]
+                            name = "Microsoft.DBforMySQL/flexibleServers"
+                        }
                     }
-                }]
+                ]
                 resourceGroupNameSelector = {
                     matchControllerRef = True
                 }

--- a/tests/e2etest-xnetwork/main.k
+++ b/tests/e2etest-xnetwork/main.k
@@ -53,7 +53,7 @@ _items = [
         }
     },
     metav1alpha1.E2ETest{
-        metadata.name = "xnetwork-azure-with-pg"
+        metadata.name = "xnetwork-azure-with-dbs"
         spec = {
             # Configure Crossplane for the test environment
             crossplane.autoUpgrade.channel = "Rapid"
@@ -66,9 +66,9 @@ _items = [
             # Define the resource to be created
             manifests = [
                 platformazurev1alpha1.XNetwork{
-                    metadata.name = "uptest-azure-network-with-db"
+                    metadata.name = "uptest-azure-network-with-dbs"
                     spec.parameters = {
-                        id = "uptest-azure-network-with-db"
+                        id = "uptest-azure-network-with-dbs"
                         region = "westus2"
                         addressRange = "10.0.0.0/16"
                         generalSubnetRange = "10.0.1.0/24"
@@ -76,59 +76,9 @@ _items = [
                             {
                                 addressRange = "10.0.2.0/24"
                                 serviceType = "postgresql"
-                            }
-                        ]
-                        deletionPolicy = "Delete"
-                        providerConfigName = "default"
-                    }
-                }
-            ]
-
-            # Define the provider configuration
-            extraResources = [
-                azurev1beta1.ProviderConfig{
-                    metadata.name = "default"
-                    spec = {
-                        credentials = {
-                            source = "Upbound"
-                        }
-                        clientID = "bcf40abd-283c-494b-b186-03d6c864be51"
-                        tenantID = "b9925bc4-8383-4c37-b9d2-fa456d1bb1c7"
-                        subscriptionID = "038f2b7c-3265-43b8-8624-c9ad5da610a8"
-                    }
-                }
-            ]
-
-            # Test cleanup settings
-            skipDelete = False
-
-            # Set a reasonable timeout for resources to be provisioned
-            timeoutSeconds = 3600
-        }
-    },
-    metav1alpha1.E2ETest{
-        metadata.name = "xnetwork-azure-with-mysql"
-        spec = {
-            # Configure Crossplane for the test environment
-            crossplane.autoUpgrade.channel = "Rapid"
-
-            # Define the conditions that indicate successful resource creation
-            defaultConditions = [
-                "Ready"
-            ]
-
-            # Define the resource to be created
-            manifests = [
-                platformazurev1alpha1.XNetwork{
-                    metadata.name = "uptest-azure-network-with-db"
-                    spec.parameters = {
-                        id = "uptest-azure-network-with-db"
-                        region = "westus2"
-                        addressRange = "10.0.0.0/16"
-                        generalSubnetRange = "10.0.1.0/24"
-                        databaseSubnets = [
+                            },
                             {
-                                addressRange = "10.0.2.0/24"
+                                addressRange = "10.0.3.0/24"
                                 serviceType = "mysql"
                             }
                         ]

--- a/tests/e2etest-xnetwork/main.k
+++ b/tests/e2etest-xnetwork/main.k
@@ -5,7 +5,7 @@ import file
 
 _items = [
     metav1alpha1.E2ETest{
-        metadata.name = "e2etest-xnetwork-azure"
+        metadata.name = "xnetwork-azure"
         spec = {
             # Configure Crossplane for the test environment
             crossplane.autoUpgrade.channel = "Rapid"
@@ -22,6 +22,8 @@ _items = [
                     spec.parameters = {
                         id = "uptest-azure-network"
                         region = "westus2"
+                        addressRange = "10.0.0.0/16"
+                        generalSubnetRange = "10.0.1.0/24"
                         deletionPolicy = "Delete"
                         providerConfigName = "default"
                     }
@@ -51,7 +53,7 @@ _items = [
         }
     },
     metav1alpha1.E2ETest{
-        metadata.name = "xnetwork-azure-with-db"
+        metadata.name = "xnetwork-azure-with-pg"
         spec = {
             # Configure Crossplane for the test environment
             crossplane.autoUpgrade.channel = "Rapid"
@@ -68,9 +70,68 @@ _items = [
                     spec.parameters = {
                         id = "uptest-azure-network-with-db"
                         region = "westus2"
-                        addressSpace = "10.0.0.0/16"
-                        generalSubnetPrefix = "10.0.1.0/24"
-                        databaseSubnetPrefix = "10.0.2.0/24"
+                        addressRange = "10.0.0.0/16"
+                        generalSubnetRange = "10.0.1.0/24"
+                        databaseSubnets = [
+                            {
+                                addressRange = "10.0.2.0/24"
+                                serviceType = "postgresql"
+                            }
+                        ]
+                        deletionPolicy = "Delete"
+                        providerConfigName = "default"
+                    }
+                }
+            ]
+
+            # Define the provider configuration
+            extraResources = [
+                azurev1beta1.ProviderConfig{
+                    metadata.name = "default"
+                    spec = {
+                        credentials = {
+                            source = "Upbound"
+                        }
+                        clientID = "bcf40abd-283c-494b-b186-03d6c864be51"
+                        tenantID = "b9925bc4-8383-4c37-b9d2-fa456d1bb1c7"
+                        subscriptionID = "038f2b7c-3265-43b8-8624-c9ad5da610a8"
+                    }
+                }
+            ]
+
+            # Test cleanup settings
+            skipDelete = False
+
+            # Set a reasonable timeout for resources to be provisioned
+            timeoutSeconds = 3600
+        }
+    },
+    metav1alpha1.E2ETest{
+        metadata.name = "xnetwork-azure-with-mysql"
+        spec = {
+            # Configure Crossplane for the test environment
+            crossplane.autoUpgrade.channel = "Rapid"
+
+            # Define the conditions that indicate successful resource creation
+            defaultConditions = [
+                "Ready"
+            ]
+
+            # Define the resource to be created
+            manifests = [
+                platformazurev1alpha1.XNetwork{
+                    metadata.name = "uptest-azure-network-with-db"
+                    spec.parameters = {
+                        id = "uptest-azure-network-with-db"
+                        region = "westus2"
+                        addressRange = "10.0.0.0/16"
+                        generalSubnetRange = "10.0.1.0/24"
+                        databaseSubnets = [
+                            {
+                                addressRange = "10.0.2.0/24"
+                                serviceType = "mysql"
+                            }
+                        ]
                         deletionPolicy = "Delete"
                         providerConfigName = "default"
                     }

--- a/tests/e2etest-xnetwork/main.k
+++ b/tests/e2etest-xnetwork/main.k
@@ -41,7 +41,55 @@ _items = [
                         subscriptionID = "038f2b7c-3265-43b8-8624-c9ad5da610a8"
                     }
                 }
+            ]
 
+            # Test cleanup settings
+            skipDelete = False
+
+            # Set a reasonable timeout for resources to be provisioned
+            timeoutSeconds = 3600
+        }
+    },
+    metav1alpha1.E2ETest{
+        metadata.name = "xnetwork-azure-with-db"
+        spec = {
+            # Configure Crossplane for the test environment
+            crossplane.autoUpgrade.channel = "Rapid"
+
+            # Define the conditions that indicate successful resource creation
+            defaultConditions = [
+                "Ready"
+            ]
+
+            # Define the resource to be created
+            manifests = [
+                platformazurev1alpha1.XNetwork{
+                    metadata.name = "uptest-azure-network-with-db"
+                    spec.parameters = {
+                        id = "uptest-azure-network-with-db"
+                        region = "westus2"
+                        addressSpace = "10.0.0.0/16"
+                        generalSubnetPrefix = "10.0.1.0/24"
+                        databaseSubnetPrefix = "10.0.2.0/24"
+                        deletionPolicy = "Delete"
+                        providerConfigName = "default"
+                    }
+                }
+            ]
+
+            # Define the provider configuration
+            extraResources = [
+                azurev1beta1.ProviderConfig{
+                    metadata.name = "default"
+                    spec = {
+                        credentials = {
+                            source = "Upbound"
+                        }
+                        clientID = "bcf40abd-283c-494b-b186-03d6c864be51"
+                        tenantID = "b9925bc4-8383-4c37-b9d2-fa456d1bb1c7"
+                        subscriptionID = "038f2b7c-3265-43b8-8624-c9ad5da610a8"
+                    }
+                }
             ]
 
             # Test cleanup settings

--- a/tests/test-xnetwork/main.k
+++ b/tests/test-xnetwork/main.k
@@ -5,7 +5,7 @@ import models.io.upbound.dev.meta.v1alpha1 as metav1alpha1
 
 _items = [
     metav1alpha1.CompositionTest{
-        metadata.name = "test-xnetwork-with-db"
+        metadata.name = "test-xnetwork-with-postgresql-db"
         spec = {
             assertResources: [
                 # The XNetwork composite resource
@@ -14,9 +14,14 @@ _items = [
                     spec.parameters = {
                         id = "ref-azure-network-from-xr"
                         region = "westus"
-                        addressSpace = "10.0.0.0/16"
-                        generalSubnetPrefix = "10.0.1.0/24"
-                        databaseSubnetPrefix = "10.0.2.0/24"
+                        addressRange = "10.0.0.0/16"
+                        generalSubnetRange = "10.0.1.0/24"
+                        databaseSubnets = [
+                            {
+                                addressRange = "10.0.2.0/24"
+                                serviceType = "postgresql"
+                            }
+                        ]
                         deletionPolicy = "Delete"
                         providerConfigName = "default"
                     }
@@ -72,30 +77,21 @@ _items = [
                     spec.providerConfigRef.name = "default"
                 }
 
-                # Database Subnet
+                # Database Subnet with PostgreSQL delegation
                 networkv1beta2.Subnet{
-                    metadata.name = "ref-azure-network-from-xr-db-sn"
+                    metadata.name = "ref-azure-network-from-xr-db-sn-0"
                     metadata.labels = {
                         "azure.platform.upbound.io/network-id" = "ref-azure-network-from-xr"
                     }
                     spec.forProvider = {
                         addressPrefixes = ["10.0.2.0/24"]
-                        delegation = [
-                            {
-                                name = "fs-postgresql"
-                                serviceDelegation = {
-                                    actions = ["Microsoft.Network/virtualNetworks/subnets/join/action"]
-                                    name = "Microsoft.DBforPostgreSQL/flexibleServers"
-                                }
-                            },
-                            {
-                                name = "fs-mysql"
-                                serviceDelegation = {
-                                    actions = ["Microsoft.Network/virtualNetworks/subnets/join/action"]
-                                        name = "Microsoft.DBforMySQL/flexibleServers"
-                                }
+                        delegation = [{
+                            name = "fs"
+                            serviceDelegation = {
+                                actions = ["Microsoft.Network/virtualNetworks/subnets/join/action"]
+                                name = "Microsoft.DBforPostgreSQL/flexibleServers"
                             }
-                        ]
+                        }]
                         resourceGroupNameSelector = {
                             matchControllerRef = True
                         }
@@ -109,7 +105,114 @@ _items = [
                 }
             ]
             compositionPath = "apis/xnetworks/composition.yaml"
-            xrPath = "examples/network-xr-with-db.yaml"
+            xrPath = "examples/network-xr-with-pg-db.yaml"
+            xrdPath = "apis/xnetworks/definition.yaml"
+            timeoutSeconds = 120
+            validate = False
+        }
+    },
+    metav1alpha1.CompositionTest{
+        metadata.name = "test-xnetwork-with-mysql-db"
+        spec = {
+            assertResources: [
+                # The XNetwork composite resource
+                platformazurev1alpha1.XNetwork{
+                    metadata.name = "ref-azure-network"
+                    spec.parameters = {
+                        id = "ref-azure-network-from-xr"
+                        region = "westus"
+                        addressRange = "10.0.0.0/16"
+                        generalSubnetRange = "10.0.1.0/24"
+                        databaseSubnets = [
+                            {
+                                addressRange = "10.0.2.0/24"
+                                serviceType = "mysql"
+                            }
+                        ]
+                        deletionPolicy = "Delete"
+                        providerConfigName = "default"
+                    }
+                }
+
+                # Resource Group
+                azurev1beta1.ResourceGroup{
+                    metadata.name = "ref-azure-network-from-xr-rg"
+                    metadata.labels = {
+                        "azure.platform.upbound.io/network-id" = "ref-azure-network-from-xr"
+                    }
+                    spec.forProvider = {
+                        location = "westus"
+                    }
+                    spec.deletionPolicy = "Delete"
+                    spec.providerConfigRef.name = "default"
+                }
+
+                # Virtual Network
+                networkv1beta2.VirtualNetwork{
+                    metadata.name = "ref-azure-network-from-xr-vnet"
+                    metadata.labels = {
+                        "azure.platform.upbound.io/network-id" = "ref-azure-network-from-xr"
+                    }
+                    spec.forProvider = {
+                        location = "westus"
+                        addressSpace = ["10.0.0.0/16"]
+                        resourceGroupNameSelector = {
+                            matchControllerRef = True
+                        }
+                    }
+                    spec.deletionPolicy = "Delete"
+                    spec.providerConfigRef.name = "default"
+                }
+
+                # General Subnet
+                networkv1beta2.Subnet{
+                    metadata.name = "ref-azure-network-from-xr-sn"
+                    metadata.labels = {
+                        "azure.platform.upbound.io/network-id" = "ref-azure-network-from-xr"
+                    }
+                    spec.forProvider = {
+                        addressPrefixes = ["10.0.1.0/24"]
+                        resourceGroupNameSelector = {
+                            matchControllerRef = True
+                        }
+                        serviceEndpoints = ["Microsoft.Sql"]
+                        virtualNetworkNameSelector = {
+                            matchControllerRef = True
+                        }
+                    }
+                    spec.deletionPolicy = "Delete"
+                    spec.providerConfigRef.name = "default"
+                }
+
+                # Database Subnet with MySQL delegation
+                networkv1beta2.Subnet{
+                    metadata.name = "ref-azure-network-from-xr-db-sn-0"
+                    metadata.labels = {
+                        "azure.platform.upbound.io/network-id" = "ref-azure-network-from-xr"
+                    }
+                    spec.forProvider = {
+                        addressPrefixes = ["10.0.2.0/24"]
+                        delegation = [{
+                            name = "fs"
+                            serviceDelegation = {
+                                actions = ["Microsoft.Network/virtualNetworks/subnets/join/action"]
+                                name = "Microsoft.DBforMySQL/flexibleServers"
+                            }
+                        }]
+                        resourceGroupNameSelector = {
+                            matchControllerRef = True
+                        }
+                        serviceEndpoints = ["Microsoft.Storage"]
+                        virtualNetworkNameSelector = {
+                            matchControllerRef = True
+                        }
+                    }
+                    spec.deletionPolicy = "Delete"
+                    spec.providerConfigRef.name = "default"
+                }
+            ]
+            compositionPath = "apis/xnetworks/composition.yaml"
+            xrPath = "examples/network-xr-with-mysql-db.yaml"
             xrdPath = "apis/xnetworks/definition.yaml"
             timeoutSeconds = 120
             validate = False
@@ -125,8 +228,8 @@ _items = [
                     spec.parameters = {
                         id = "ref-azure-network-from-xr"
                         region = "westus"
-                        addressSpace = "10.0.0.0/16"
-                        generalSubnetPrefix = "10.0.1.0/24"
+                        addressRange = "10.0.0.0/16"
+                        generalSubnetRange = "10.0.1.0/24"
                         deletionPolicy = "Delete"
                         providerConfigName = "default"
                     }

--- a/tests/test-xnetwork/main.k
+++ b/tests/test-xnetwork/main.k
@@ -14,6 +14,9 @@ _items = [
                     spec.parameters = {
                         id = "ref-azure-network-from-xr"
                         region = "westus"
+                        addressSpace = "10.0.0.0/16"
+                        generalSubnetPrefix = "10.0.1.0/24"
+                        databaseSubnetPrefix = "10.0.2.0/24"
                         deletionPolicy = "Delete"
                         providerConfigName = "default"
                     }
@@ -69,9 +72,9 @@ _items = [
                     spec.providerConfigRef.name = "default"
                 }
 
-                # PostgreSQL Subnet
+                # Database Subnet
                 networkv1beta2.Subnet{
-                    metadata.name = "ref-azure-network-from-xr-psql-sn"
+                    metadata.name = "ref-azure-network-from-xr-db-sn"
                     metadata.labels = {
                         "azure.platform.upbound.io/network-id" = "ref-azure-network-from-xr"
                     }

--- a/tests/test-xnetwork/main.k
+++ b/tests/test-xnetwork/main.k
@@ -291,6 +291,144 @@ _items = [
             timeoutSeconds = 120
             validate = False
         }
+    },
+    metav1alpha1.CompositionTest{
+        metadata.name = "test-xnetwork-with-multiple-dbs"
+        spec = {
+            assertResources: [
+                # The XNetwork composite resource
+                platformazurev1alpha1.XNetwork{
+                    metadata.name = "ref-azure-network"
+                    spec.parameters = {
+                        id = "ref-azure-network-from-xr"
+                        region = "westus"
+                        addressRange = "10.0.0.0/16"
+                        generalSubnetRange = "10.0.1.0/24"
+                        databaseSubnets = [
+                            {
+                                addressRange = "10.0.2.0/24"
+                                serviceType = "postgresql"
+                            },
+                            {
+                                addressRange = "10.0.3.0/24"
+                                serviceType = "mysql"
+                            }
+                        ]
+                        deletionPolicy = "Delete"
+                        providerConfigName = "default"
+                    }
+                }
+
+                # Resource Group
+                azurev1beta1.ResourceGroup{
+                    metadata.name = "ref-azure-network-from-xr-rg"
+                    metadata.labels = {
+                        "azure.platform.upbound.io/network-id" = "ref-azure-network-from-xr"
+                    }
+                    spec.forProvider = {
+                        location = "westus"
+                    }
+                    spec.deletionPolicy = "Delete"
+                    spec.providerConfigRef.name = "default"
+                }
+
+                # Virtual Network
+                networkv1beta2.VirtualNetwork{
+                    metadata.name = "ref-azure-network-from-xr-vnet"
+                    metadata.labels = {
+                        "azure.platform.upbound.io/network-id" = "ref-azure-network-from-xr"
+                    }
+                    spec.forProvider = {
+                        location = "westus"
+                        addressSpace = ["10.0.0.0/16"]
+                        resourceGroupNameSelector = {
+                            matchControllerRef = True
+                        }
+                    }
+                    spec.deletionPolicy = "Delete"
+                    spec.providerConfigRef.name = "default"
+                }
+
+                # General Subnet
+                networkv1beta2.Subnet{
+                    metadata.name = "ref-azure-network-from-xr-sn"
+                    metadata.labels = {
+                        "azure.platform.upbound.io/network-id" = "ref-azure-network-from-xr"
+                    }
+                    spec.forProvider = {
+                        addressPrefixes = ["10.0.1.0/24"]
+                        resourceGroupNameSelector = {
+                            matchControllerRef = True
+                        }
+                        serviceEndpoints = ["Microsoft.Sql"]
+                        virtualNetworkNameSelector = {
+                            matchControllerRef = True
+                        }
+                    }
+                    spec.deletionPolicy = "Delete"
+                    spec.providerConfigRef.name = "default"
+                }
+
+                # Database Subnet with PostgreSQL delegation
+                networkv1beta2.Subnet{
+                    metadata.name = "ref-azure-network-from-xr-db-sn-0"
+                    metadata.labels = {
+                        "azure.platform.upbound.io/network-id" = "ref-azure-network-from-xr"
+                    }
+                    spec.forProvider = {
+                        addressPrefixes = ["10.0.2.0/24"]
+                        delegation = [{
+                            name = "fs"
+                            serviceDelegation = {
+                                actions = ["Microsoft.Network/virtualNetworks/subnets/join/action"]
+                                name = "Microsoft.DBforPostgreSQL/flexibleServers"
+                            }
+                        }]
+                        resourceGroupNameSelector = {
+                            matchControllerRef = True
+                        }
+                        serviceEndpoints = ["Microsoft.Storage"]
+                        virtualNetworkNameSelector = {
+                            matchControllerRef = True
+                        }
+                    }
+                    spec.deletionPolicy = "Delete"
+                    spec.providerConfigRef.name = "default"
+                }
+
+                # Database Subnet with MySQL delegation
+                networkv1beta2.Subnet{
+                    metadata.name = "ref-azure-network-from-xr-db-sn-1"
+                    metadata.labels = {
+                        "azure.platform.upbound.io/network-id" = "ref-azure-network-from-xr"
+                    }
+                    spec.forProvider = {
+                        addressPrefixes = ["10.0.3.0/24"]
+                        delegation = [{
+                            name = "fs"
+                            serviceDelegation = {
+                                actions = ["Microsoft.Network/virtualNetworks/subnets/join/action"]
+                                name = "Microsoft.DBforMySQL/flexibleServers"
+                            }
+                        }]
+                        resourceGroupNameSelector = {
+                            matchControllerRef = True
+                        }
+                        serviceEndpoints = ["Microsoft.Storage"]
+                        virtualNetworkNameSelector = {
+                            matchControllerRef = True
+                        }
+                    }
+                    spec.deletionPolicy = "Delete"
+                    spec.providerConfigRef.name = "default"
+                }
+            ]
+            compositionPath = "apis/xnetworks/composition.yaml"
+            xrPath = "examples/network-xr-with-multiple-dbs.yaml"
+            xrdPath = "apis/xnetworks/definition.yaml"
+            timeoutSeconds = 120
+            validate = False
+        }
     }
 ]
 

--- a/tests/test-xnetwork/main.k
+++ b/tests/test-xnetwork/main.k
@@ -80,13 +80,22 @@ _items = [
                     }
                     spec.forProvider = {
                         addressPrefixes = ["10.0.2.0/24"]
-                        delegation = [{
-                            name = "fs"
-                            serviceDelegation = {
-                                actions = ["Microsoft.Network/virtualNetworks/subnets/join/action"]
-                                name = "Microsoft.DBforPostgreSQL/flexibleServers"
+                        delegation = [
+                            {
+                                name = "fs-postgresql"
+                                serviceDelegation = {
+                                    actions = ["Microsoft.Network/virtualNetworks/subnets/join/action"]
+                                    name = "Microsoft.DBforPostgreSQL/flexibleServers"
+                                }
+                            },
+                            {
+                                name = "fs-mysql"
+                                serviceDelegation = {
+                                    actions = ["Microsoft.Network/virtualNetworks/subnets/join/action"]
+                                        name = "Microsoft.DBforMySQL/flexibleServers"
+                                }
                             }
-                        }]
+                        ]
                         resourceGroupNameSelector = {
                             matchControllerRef = True
                         }

--- a/tests/test-xnetwork/main.k
+++ b/tests/test-xnetwork/main.k
@@ -40,7 +40,7 @@ _items = [
                     }
                     spec.forProvider = {
                         location = "westus"
-                        addressSpace = ["192.168.0.0/16"]
+                        addressSpace = ["10.0.0.0/16"]
                         resourceGroupNameSelector = {
                             matchControllerRef = True
                         }
@@ -49,18 +49,45 @@ _items = [
                     spec.providerConfigRef.name = "default"
                 }
 
-                # Subnet
+                # General Subnet
                 networkv1beta2.Subnet{
                     metadata.name = "ref-azure-network-from-xr-sn"
                     metadata.labels = {
                         "azure.platform.upbound.io/network-id" = "ref-azure-network-from-xr"
                     }
                     spec.forProvider = {
-                        addressPrefixes = ["192.168.1.0/24"]
+                        addressPrefixes = ["10.0.1.0/24"]
                         resourceGroupNameSelector = {
                             matchControllerRef = True
                         }
                         serviceEndpoints = ["Microsoft.Sql"]
+                        virtualNetworkNameSelector = {
+                            matchControllerRef = True
+                        }
+                    }
+                    spec.deletionPolicy = "Delete"
+                    spec.providerConfigRef.name = "default"
+                }
+
+                # PostgreSQL Subnet
+                networkv1beta2.Subnet{
+                    metadata.name = "ref-azure-network-from-xr-psql-sn"
+                    metadata.labels = {
+                        "azure.platform.upbound.io/network-id" = "ref-azure-network-from-xr"
+                    }
+                    spec.forProvider = {
+                        addressPrefixes = ["10.0.2.0/24"]
+                        delegation = [{
+                            name = "fs"
+                            serviceDelegation = {
+                                actions = ["Microsoft.Network/virtualNetworks/subnets/join/action"]
+                                name = "Microsoft.DBforPostgreSQL/flexibleServers"
+                            }
+                        }]
+                        resourceGroupNameSelector = {
+                            matchControllerRef = True
+                        }
+                        serviceEndpoints = ["Microsoft.Storage"]
                         virtualNetworkNameSelector = {
                             matchControllerRef = True
                         }

--- a/tests/test-xnetwork/main.k
+++ b/tests/test-xnetwork/main.k
@@ -5,7 +5,7 @@ import models.io.upbound.dev.meta.v1alpha1 as metav1alpha1
 
 _items = [
     metav1alpha1.CompositionTest{
-        metadata.name = "test-xnetwork"
+        metadata.name = "test-xnetwork-with-db"
         spec = {
             assertResources: [
                 # The XNetwork composite resource
@@ -91,6 +91,80 @@ _items = [
                             matchControllerRef = True
                         }
                         serviceEndpoints = ["Microsoft.Storage"]
+                        virtualNetworkNameSelector = {
+                            matchControllerRef = True
+                        }
+                    }
+                    spec.deletionPolicy = "Delete"
+                    spec.providerConfigRef.name = "default"
+                }
+            ]
+            compositionPath = "apis/xnetworks/composition.yaml"
+            xrPath = "examples/network-xr-with-db.yaml"
+            xrdPath = "apis/xnetworks/definition.yaml"
+            timeoutSeconds = 120
+            validate = False
+        }
+    },
+    metav1alpha1.CompositionTest{
+        metadata.name = "test-xnetwork-without-db"
+        spec = {
+            assertResources: [
+                # The XNetwork composite resource
+                platformazurev1alpha1.XNetwork{
+                    metadata.name = "ref-azure-network"
+                    spec.parameters = {
+                        id = "ref-azure-network-from-xr"
+                        region = "westus"
+                        addressSpace = "10.0.0.0/16"
+                        generalSubnetPrefix = "10.0.1.0/24"
+                        deletionPolicy = "Delete"
+                        providerConfigName = "default"
+                    }
+                }
+
+                # Resource Group
+                azurev1beta1.ResourceGroup{
+                    metadata.name = "ref-azure-network-from-xr-rg"
+                    metadata.labels = {
+                        "azure.platform.upbound.io/network-id" = "ref-azure-network-from-xr"
+                    }
+                    spec.forProvider = {
+                        location = "westus"
+                    }
+                    spec.deletionPolicy = "Delete"
+                    spec.providerConfigRef.name = "default"
+                }
+
+                # Virtual Network
+                networkv1beta2.VirtualNetwork{
+                    metadata.name = "ref-azure-network-from-xr-vnet"
+                    metadata.labels = {
+                        "azure.platform.upbound.io/network-id" = "ref-azure-network-from-xr"
+                    }
+                    spec.forProvider = {
+                        location = "westus"
+                        addressSpace = ["10.0.0.0/16"]
+                        resourceGroupNameSelector = {
+                            matchControllerRef = True
+                        }
+                    }
+                    spec.deletionPolicy = "Delete"
+                    spec.providerConfigRef.name = "default"
+                }
+
+                # General Subnet
+                networkv1beta2.Subnet{
+                    metadata.name = "ref-azure-network-from-xr-sn"
+                    metadata.labels = {
+                        "azure.platform.upbound.io/network-id" = "ref-azure-network-from-xr"
+                    }
+                    spec.forProvider = {
+                        addressPrefixes = ["10.0.1.0/24"]
+                        resourceGroupNameSelector = {
+                            matchControllerRef = True
+                        }
+                        serviceEndpoints = ["Microsoft.Sql"]
                         virtualNetworkNameSelector = {
                             matchControllerRef = True
                         }


### PR DESCRIPTION
<!--
Thank you for helping to improve Upbound!

Please read through https://git.io/fj2m9 if this is your first time opening an
Upbound pull request. Find us in https://slack.crossplane.io/messages/upbound if
you need any help contributing.
-->

### Description of your changes

* Parametrize network ranges
* Add optional database subnets in preparation for migration to Flexible Server in configuration-azure-database.

Relates to https://github.com/upbound/configuration-azure-database/issues/90

I have:

- [x] Read and followed Upbound's [contribution process](https://git.io/fj2m9).
- [ ] Run `make reviewable` to ensure this PR is ready for review.
- [ ] Added `backport release-x.y` labels to auto-backport this PR, as appropriate.

### How has this code been tested

```
up test run tests/* 
...
  ✓   Pushing embedded functions to local daemon
  ✓   Assert test-xnetwork-with-postgresql-db
  ✓   Assert test-xnetwork-with-mysql-db
  ✓   Assert test-xnetwork-without-db
  ✓   Assert test-xnetwork-with-multiple-dbs
 SUCCESS
 SUCCESS  Tests Summary:
 SUCCESS  ------------------
 SUCCESS  Total Tests Executed: 4
 SUCCESS  Passed tests:         4
 SUCCESS  Failed tests:         0
 SUCCESS
 SUCCESS  Tests Summary:
 SUCCESS  ------------------
 SUCCESS  Total Tests Executed: 2
 SUCCESS  Passed tests:         2
 SUCCESS  Failed tests:         0

up test run tests/* --e2e
...
 SUCCESS
 SUCCESS  Tests Summary:
 SUCCESS  ------------------
 SUCCESS  Total Tests Executed: 2
 SUCCESS  Passed tests:         2
 SUCCESS  Failed tests:         0
```