### PR TITLE
Assign service type labels to database subnets

### DIFF
--- a/functions/xnetwork/main.k
+++ b/functions/xnetwork/main.k
@@ -79,7 +79,11 @@ _base_resources = [
 _subnets_from_spec = params.databaseSubnets or []
 _database_subnets = [
     networkv1beta2.Subnet {
-        metadata = _metadata("${params.id}-db-sn-${index}")
+        metadata = _metadata("${params.id}-db-sn-${index}") | {
+            labels: {
+                "azure.platform.upbound.io/subnet-service-type" = subnet.serviceType
+            }
+        }
         spec = _add_common_spec_fields(networkv1beta2.NetworkAzureUpboundIoV1beta2SubnetSpec {
             forProvider = {
                 addressPrefixes = [subnet.addressRange]

--- a/tests/test-xnetwork/main.k
+++ b/tests/test-xnetwork/main.k
@@ -374,6 +374,7 @@ _items = [
                     metadata.name = "ref-azure-network-from-xr-db-sn-0"
                     metadata.labels = {
                         "azure.platform.upbound.io/network-id" = "ref-azure-network-from-xr"
+                        "azure.platform.upbound.io/subnet-service-type" = "postgresql"
                     }
                     spec.forProvider = {
                         addressPrefixes = ["10.0.2.0/24"]
@@ -401,6 +402,7 @@ _items = [
                     metadata.name = "ref-azure-network-from-xr-db-sn-1"
                     metadata.labels = {
                         "azure.platform.upbound.io/network-id" = "ref-azure-network-from-xr"
+                        "azure.platform.upbound.io/subnet-service-type" = "mysql"
                     }
                     spec.forProvider = {
                         addressPrefixes = ["10.0.3.0/24"]


### PR DESCRIPTION
<!--
Thank you for helping to improve Upbound!

Please read through https://git.io/fj2m9 if this is your first time opening an
Upbound pull request. Find us in https://slack.crossplane.io/messages/upbound if
you need any help contributing.
-->

### Description of your changes

Assign service type labels to database subnets

will be used by configuration-azure-database for effective subnet selection

I have:

- [ ] Read and followed Upbound's [contribution process](https://git.io/fj2m9).
- [ ] Run `make reviewable` to ensure this PR is ready for review.
- [ ] Added `backport release-x.y` labels to auto-backport this PR, as appropriate.

### How has this code been tested

```
up test run tests/*
  ✓   Parsing tests
  ✓   Checking dependencies
  ✓   Generating language schemas
  ✓   Building functions
  ✓   Checking dependencies
  ✓   Generating language schemas
  ✓   Building functions                                                                                                                   ✓   Checking dependencies                                                                                                                ✓   Generating language schemas
  ✓   Building functions
  ✓   Checking dependencies                                                                                                                ✓   Generating language schemas                                                                                                          ✓   Building functions
  ✓   Checking dependencies
  ✓   Generating language schemas                                                                                                          ✓   Building functions                                                                                                                   ✓   Building configuration package
  ✓   Pushing embedded functions to local daemon
  ✓   Assert test-xnetwork-with-postgresql-db                                                                                              ✓   Assert test-xnetwork-with-mysql-db                                                                                                   ✓   Assert test-xnetwork-without-db
  ✓   Assert test-xnetwork-with-multiple-dbs
 SUCCESS
 SUCCESS  Tests Summary:
 SUCCESS  ------------------
 SUCCESS  Total Tests Executed: 4
 SUCCESS  Passed tests:         4
 SUCCESS  Failed tests:         0
```


