### PR TITLE
Small enum update

### DIFF
--- a/apis/xnetworks/definition.yaml
+++ b/apis/xnetworks/definition.yaml
@@ -47,7 +47,7 @@ spec:
                         serviceType:
                           type: string
                           description: Type of database service to use (postgresql or mysql)
-                          enum: ["postgresql", "mysql"]
+                          enum: ["postgres", "mysql"]
                       required:
                         - addressRange
                         - serviceType

--- a/examples/network-xr-with-multiple-dbs.yaml
+++ b/examples/network-xr-with-multiple-dbs.yaml
@@ -10,6 +10,6 @@ spec:
     generalSubnetRange: 10.0.1.0/24
     databaseSubnets:
       - addressRange: 10.0.2.0/24
-        serviceType: postgresql
+        serviceType: postgres
       - addressRange: 10.0.3.0/24
         serviceType: mysql

--- a/examples/network-xr-with-pg-db.yaml
+++ b/examples/network-xr-with-pg-db.yaml
@@ -10,6 +10,6 @@ spec:
     generalSubnetRange: 10.0.1.0/24
     databaseSubnets:
       - addressRange: 10.0.2.0/24
-        serviceType: postgresql
+        serviceType: postgres
     deletionPolicy: Delete
     providerConfigName: default

--- a/functions/xnetwork/main.k
+++ b/functions/xnetwork/main.k
@@ -95,7 +95,7 @@ _database_subnets = [
                     name = "fs"
                     serviceDelegation = {
                         actions = ["Microsoft.Network/virtualNetworks/subnets/join/action"]
-                        name = "Microsoft.DBforPostgreSQL/flexibleServers" if subnet.serviceType == "postgresql" else "Microsoft.DBforMySQL/flexibleServers"
+                        name = "Microsoft.DBforPostgreSQL/flexibleServers" if subnet.serviceType == "postgres" else "Microsoft.DBforMySQL/flexibleServers"
                     }
                 }]
                 resourceGroupNameSelector = {

--- a/tests/e2etest-xnetwork/main.k
+++ b/tests/e2etest-xnetwork/main.k
@@ -75,7 +75,7 @@ _items = [
                         databaseSubnets = [
                             {
                                 addressRange = "10.0.2.0/24"
-                                serviceType = "postgresql"
+                                serviceType = "postgres"
                             },
                             {
                                 addressRange = "10.0.3.0/24"

--- a/tests/test-xnetwork/main.k
+++ b/tests/test-xnetwork/main.k
@@ -19,7 +19,7 @@ _items = [
                         databaseSubnets = [
                             {
                                 addressRange = "10.0.2.0/24"
-                                serviceType = "postgresql"
+                                serviceType = "postgres"
                             }
                         ]
                         deletionPolicy = "Delete"
@@ -83,7 +83,7 @@ _items = [
                     metadata.name = "ref-azure-network-from-xr-db-sn-0"
                     metadata.labels = {
                         "azure.platform.upbound.io/network-id" = "ref-azure-network-from-xr"
-                        "azure.platform.upbound.io/subnet-service-type" = "postgresql"
+                        "azure.platform.upbound.io/subnet-service-type" = "postgres"
                     }
                     spec.forProvider = {
                         addressPrefixes = ["10.0.2.0/24"]
@@ -311,7 +311,7 @@ _items = [
                         databaseSubnets = [
                             {
                                 addressRange = "10.0.2.0/24"
-                                serviceType = "postgresql"
+                                serviceType = "postgres"
                             },
                             {
                                 addressRange = "10.0.3.0/24"
@@ -378,7 +378,7 @@ _items = [
                     metadata.name = "ref-azure-network-from-xr-db-sn-0"
                     metadata.labels = {
                         "azure.platform.upbound.io/network-id" = "ref-azure-network-from-xr"
-                        "azure.platform.upbound.io/subnet-service-type" = "postgresql"
+                        "azure.platform.upbound.io/subnet-service-type" = "postgres"
                     }
                     spec.forProvider = {
                         addressPrefixes = ["10.0.2.0/24"]


### PR DESCRIPTION
### Description of your changes

Updating `postgresql` enum to `postgres` to align with `aws` and `gcp` configurations.

Related PR: [https://github.com/upbound/configuration-azure-database/pull/104](https://github.com/upbound/configuration-azure-database/pull/104)

I have:

- [x] Read and followed Upbound's [contribution process](https://git.io/fj2m9).
- [x] Run `make reviewable` to ensure this PR is ready for review.
- [x] Added `backport release-x.y` labels to auto-backport this PR, as appropriate.

### How has this code been tested
`up test run tests/*`