### PR TITLE
We need to label general subnet for deterministic selection

### DIFF
--- a/functions/xnetwork/main.k
+++ b/functions/xnetwork/main.k
@@ -59,7 +59,11 @@ _base_resources = [
 
     # Subnet for general use
     networkv1beta2.Subnet {
-        metadata = _metadata("${params.id}-sn")
+        metadata = _metadata("${params.id}-sn") | {
+            labels: {
+                "azure.platform.upbound.io/subnet-service-type" = "general"
+            }
+        }
         spec = _add_common_spec_fields(networkv1beta2.NetworkAzureUpboundIoV1beta2SubnetSpec {
             forProvider = {
                 addressPrefixes = [params.generalSubnetRange]

--- a/tests/test-xnetwork/main.k
+++ b/tests/test-xnetwork/main.k
@@ -62,6 +62,7 @@ _items = [
                     metadata.name = "ref-azure-network-from-xr-sn"
                     metadata.labels = {
                         "azure.platform.upbound.io/network-id" = "ref-azure-network-from-xr"
+                        "azure.platform.upbound.io/subnet-service-type" = "general"
                     }
                     spec.forProvider = {
                         addressPrefixes = ["10.0.1.0/24"]
@@ -82,6 +83,7 @@ _items = [
                     metadata.name = "ref-azure-network-from-xr-db-sn-0"
                     metadata.labels = {
                         "azure.platform.upbound.io/network-id" = "ref-azure-network-from-xr"
+                        "azure.platform.upbound.io/subnet-service-type" = "postgresql"
                     }
                     spec.forProvider = {
                         addressPrefixes = ["10.0.2.0/24"]
@@ -169,6 +171,7 @@ _items = [
                     metadata.name = "ref-azure-network-from-xr-sn"
                     metadata.labels = {
                         "azure.platform.upbound.io/network-id" = "ref-azure-network-from-xr"
+                        "azure.platform.upbound.io/subnet-service-type" = "general"
                     }
                     spec.forProvider = {
                         addressPrefixes = ["10.0.1.0/24"]
@@ -189,6 +192,7 @@ _items = [
                     metadata.name = "ref-azure-network-from-xr-db-sn-0"
                     metadata.labels = {
                         "azure.platform.upbound.io/network-id" = "ref-azure-network-from-xr"
+                        "azure.platform.upbound.io/subnet-service-type" = "mysql"
                     }
                     spec.forProvider = {
                         addressPrefixes = ["10.0.2.0/24"]


### PR DESCRIPTION
<!--
Thank you for helping to improve Upbound!

Please read through https://git.io/fj2m9 if this is your first time opening an
Upbound pull request. Find us in https://slack.crossplane.io/messages/upbound if
you need any help contributing.
-->

### Description of your changes

We need to label a general subnet for deterministic selection in the higher level abstractions like XAKS and platform-ref-azure


I have:

- [ ] Read and followed Upbound's [contribution process](https://git.io/fj2m9).
- [ ] Run `make reviewable` to ensure this PR is ready for review.
- [ ] Added `backport release-x.y` labels to auto-backport this PR, as appropriate.

### How has this code been tested

e2e including higher level platform-ref-azure