### PR TITLE
fix(kcl): avoid full OXR cast to prevent conditions type error

### DIFF
--- a/functions/network/main.k
+++ b/functions/network/main.k
@@ -5,8 +5,12 @@ import models.io.upbound.platform.azure.v1alpha1 as platformazurev1alpha1
 import models.k8s.apimachinery.pkg.apis.meta.v1 as metav1
 
 # observed composite resource
-oxr = platformazurev1alpha1.Network{**option("params").oxr}
-params = oxr.spec.parameters
+# Note: avoid casting the full OXR (e.g. Network{**oxr}) because the
+# auto-generated model types status.conditions as a typed list which is
+# incompatible with the generic list Crossplane passes at runtime.
+# Instead, keep the raw OXR and cast only the sub-fields we need.
+oxr = option("params").oxr
+params = platformazurev1alpha1.Network.spec.parameters{**oxr.spec.parameters}
 # observed composed resources
 _ocds = option("params").ocds
 # desired composite resource


### PR DESCRIPTION
## Summary
- Use partial cast pattern for OXR deserialization: keep raw `oxr` and cast only `spec.parameters` to the typed model
- Prevents `EvaluationError` on `status.conditions` where the auto-generated KCL model expects a typed list but Crossplane passes a generic list at runtime
- This error manifests on Crossplane v2 where `status.conditions` is populated on XRs during reconciliation

## Details
The auto-generated KCL model types `status.conditions` as `[SpecificConditionType]`, but Crossplane populates it as a generic JSON list at runtime. Full OXR casting (`oxr = Type{**option("params").oxr}`) includes this field, causing:
```
EvaluationError: conditions?: [TypedList] — expect [...], got list
```

The fix follows the proven pattern from configuration-azure-aks v0.16.0:
```kcl
# Before (fails):
oxr = platformazurev1alpha1.Network{**option("params").oxr}
params = oxr.spec.parameters

# After (works, preserves type safety on parameters):
oxr = option("params").oxr
params = platformazurev1alpha1.Network.spec.parameters{**oxr.spec.parameters}
```

## Test plan
- [ ] `up project build` succeeds
- [ ] Deploy on Crossplane v2 control plane and verify XNetwork reconciles without KCL errors